### PR TITLE
Support for no_std environments

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,9 +6,13 @@ categories = ["floating point"]
 description = "Arbitrary-precision floating point library"
 documentation = "https://docs.rs/arpfloat/"
 edition = "2021"
-keywords = ["float"]
+keywords = ["float", "no-std"]
 license = "Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/nadavrot/arpfloat"
 
 [dependencies]
+
+[features]
+default = ["std"]
+std = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,11 +2,11 @@
 name = "arpfloat"
 version = "0.1.2"
 authors = ["Nadav Rotem <nadav256@gmail.com>"]
-categories = ["floating point"]
+categories = ["floating point", "no-std"]
 description = "Arbitrary-precision floating point library"
 documentation = "https://docs.rs/arpfloat/"
 edition = "2021"
-keywords = ["float", "no-std"]
+keywords = ["float"]
 license = "Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/nadavrot/arpfloat"

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ ARPFloat is an implementation of arbitrary precision
 [floating point](https://en.wikipedia.org/wiki/IEEE_754) data
 structures and utilities. The library can be used to emulate floating point
 operation, in software, or create new floating point data types.
+`no_std` environments are supported by disabling the `std` feature.
 
 ### Example
 

--- a/src/arithmetic.rs
+++ b/src/arithmetic.rs
@@ -3,6 +3,7 @@ use crate::BigInt;
 
 use super::bigint::LossFraction;
 use core::ops::{Add, Div, Mul, Sub};
+use core::cmp::Ordering;
 use super::float::{shift_right_with_loss, Category, Float, RoundingMode};
 
 #[cfg(test)]
@@ -33,14 +34,14 @@ impl<const EXPONENT: usize, const MANTISSA: usize, const PARTS: usize>
             // Align the input numbers. We shift LHS one bit to the left to
             // allow carry/borrow in case of underflow as result of subtraction.
             match bits.cmp(&0) {
-                core::cmp::Ordering::Equal => {
+                Ordering::Equal => {
                     loss = LossFraction::ExactlyZero;
                 }
-                core::cmp::Ordering::Greater => {
+                Ordering::Greater => {
                     loss = b.shift_significand_right((bits - 1) as u64);
                     a.shift_significand_left(1);
                 }
-                core::cmp::Ordering::Less => {
+                Ordering::Less => {
                     loss = a.shift_significand_right((-bits - 1) as u64);
                     b.shift_significand_left(1);
                 }
@@ -550,15 +551,15 @@ impl<const EXPONENT: usize, const MANTISSA: usize, const PARTS: usize>
         let reminder = reminder_2x.cmp(&b_mantissa);
         let is_zero = reminder_2x.is_zero();
         let loss = match reminder {
-            core::cmp::Ordering::Less => {
+            Ordering::Less => {
                 if is_zero {
                     LossFraction::ExactlyZero
                 } else {
                     LossFraction::LessThanHalf
                 }
             }
-            core::cmp::Ordering::Equal => LossFraction::ExactlyHalf,
-            core::cmp::Ordering::Greater => LossFraction::MoreThanHalf,
+            Ordering::Equal => LossFraction::ExactlyHalf,
+            Ordering::Greater => LossFraction::MoreThanHalf,
         };
 
         let x = Self::new(sign, exp, a_mantissa);

--- a/src/arithmetic.rs
+++ b/src/arithmetic.rs
@@ -1,9 +1,12 @@
+extern crate alloc;
 use crate::BigInt;
 
 use super::bigint::LossFraction;
-use std::ops::{Add, Div, Mul, Sub};
-
+use core::ops::{Add, Div, Mul, Sub};
 use super::float::{shift_right_with_loss, Category, Float, RoundingMode};
+
+#[cfg(test)]
+use crate::std::string::ToString;
 
 impl<const EXPONENT: usize, const MANTISSA: usize, const PARTS: usize>
     Float<EXPONENT, MANTISSA, PARTS>
@@ -30,14 +33,14 @@ impl<const EXPONENT: usize, const MANTISSA: usize, const PARTS: usize>
             // Align the input numbers. We shift LHS one bit to the left to
             // allow carry/borrow in case of underflow as result of subtraction.
             match bits.cmp(&0) {
-                std::cmp::Ordering::Equal => {
+                core::cmp::Ordering::Equal => {
                     loss = LossFraction::ExactlyZero;
                 }
-                std::cmp::Ordering::Greater => {
+                core::cmp::Ordering::Greater => {
                     loss = b.shift_significand_right((bits - 1) as u64);
                     a.shift_significand_left(1);
                 }
-                std::cmp::Ordering::Less => {
+                core::cmp::Ordering::Less => {
                     loss = a.shift_significand_right((-bits - 1) as u64);
                     b.shift_significand_left(1);
                 }
@@ -231,6 +234,7 @@ fn add_denormals() {
     assert_eq!(add_f64(10000., v0), 10000. + v0);
 }
 
+#[cfg(feature = "std")]
 #[test]
 fn add_special_values() {
     use crate::utils;
@@ -421,6 +425,7 @@ fn mul_regular_values() {
     }
 }
 
+#[cfg(feature = "std")]
 #[test]
 fn test_mul_special_values() {
     use super::utils;
@@ -545,15 +550,15 @@ impl<const EXPONENT: usize, const MANTISSA: usize, const PARTS: usize>
         let reminder = reminder_2x.cmp(&b_mantissa);
         let is_zero = reminder_2x.is_zero();
         let loss = match reminder {
-            std::cmp::Ordering::Less => {
+            core::cmp::Ordering::Less => {
                 if is_zero {
                     LossFraction::ExactlyZero
                 } else {
                     LossFraction::LessThanHalf
                 }
             }
-            std::cmp::Ordering::Equal => LossFraction::ExactlyHalf,
-            std::cmp::Ordering::Greater => LossFraction::MoreThanHalf,
+            core::cmp::Ordering::Equal => LossFraction::ExactlyHalf,
+            core::cmp::Ordering::Greater => LossFraction::MoreThanHalf,
         };
 
         let x = Self::new(sign, exp, a_mantissa);
@@ -577,6 +582,7 @@ fn test_div_simple() {
     assert_eq!(r0, r1);
 }
 
+#[cfg(feature = "std")]
 #[test]
 fn test_div_special_values() {
     use super::utils;
@@ -685,6 +691,7 @@ fn test_slow_sqrt_2_test() {
     assert!(res.as_f64() > 1.4142134_f64);
 }
 
+#[cfg(feature = "std")]
 #[test]
 fn test_famous_pentium4_bug() {
     // https://en.wikipedia.org/wiki/Pentium_FDIV_bug

--- a/src/bigint.rs
+++ b/src/bigint.rs
@@ -1,5 +1,14 @@
-use std::cmp::Ordering;
-use std::ops::{Add, Div, Mul, Sub};
+extern crate alloc;
+
+use core::cmp::Ordering;
+use core::ops::{Add, Div, Mul, Sub};
+#[cfg(test)]
+use alloc::vec::Vec;
+use alloc::string::String;
+
+#[cfg(feature = "std")]
+use std::{print, println};
+
 
 /// Reports the kind of values that are lost when we shift right bits. In some
 /// context this used as the two guard bits.
@@ -486,6 +495,7 @@ impl<const PARTS: usize> BigInt<PARTS> {
         self.parts[idx]
     }
 
+    #[cfg(feature = "std")]
     pub fn dump(&self) {
         print!("[");
         for i in (0..PARTS).rev() {
@@ -745,13 +755,13 @@ impl<const PARTS: usize> PartialOrd for BigInt<PARTS> {
     }
 }
 impl<const PARTS: usize> Ord for BigInt<PARTS> {
-    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+    fn cmp(&self, other: &Self) -> Ordering {
         // Compare all of the digits, from MSB to LSB.
         for i in (0..PARTS).rev() {
             match self.parts[i].cmp(&other.parts[i]) {
-                std::cmp::Ordering::Less => return Ordering::Less,
-                std::cmp::Ordering::Equal => {}
-                std::cmp::Ordering::Greater => return Ordering::Greater,
+                Ordering::Less => return Ordering::Less,
+                Ordering::Equal => {}
+                Ordering::Greater => return Ordering::Greater,
             }
         }
         Ordering::Equal
@@ -849,6 +859,7 @@ fn test_flip_bit() {
     }
 }
 
+#[cfg(feature = "std")]
 #[test]
 fn test_mul_div_encode_decode() {
     // Take a string of symbols and encode them into one large number.

--- a/src/cast.rs
+++ b/src/cast.rs
@@ -465,6 +465,7 @@ fn test_load_store_all_f32() {
     }
 }
 
+#[cfg(feature = "std")]
 #[test]
 fn test_cast_down_complex() {
     // Try casting a bunch of difficult values such as inf, nan, denormals, etc.
@@ -476,6 +477,7 @@ fn test_cast_down_complex() {
     }
 }
 
+#[cfg(feature = "std")]
 #[test]
 fn test_trunc() {
     use super::utils::Lfsr;
@@ -516,6 +518,7 @@ fn test_trunc() {
     }
 }
 
+#[cfg(feature = "std")]
 #[test]
 fn test_round() {
     use super::utils::Lfsr;
@@ -557,6 +560,7 @@ fn test_round() {
     }
 }
 
+#[cfg(feature = "std")]
 #[test]
 fn test_cast_sizes() {
     use crate::FP16;

--- a/src/float.rs
+++ b/src/float.rs
@@ -1,5 +1,9 @@
+extern crate alloc;
 use super::bigint::BigInt;
 use super::bigint::LossFraction;
+
+#[cfg(feature = "std")]
+use std::println;
 
 /// Defines the supported rounding modes.
 /// See IEEE754-2019 Section 4.3 Rounding-direction attributes
@@ -196,6 +200,7 @@ impl<const EXPONENT: usize, const MANTISSA: usize, const PARTS: usize>
     }
 
     /// Prints the number using the internal representation.
+    #[cfg(feature = "std")]
     pub fn dump(&self) {
         let sign = if self.sign { "-" } else { "+" };
         match self.category {
@@ -451,7 +456,7 @@ impl<const EXPONENT: usize, const MANTISSA: usize, const PARTS: usize>
     } // round.
 }
 
-use std::cmp::Ordering;
+use core::cmp::Ordering;
 
 impl<const EXPONENT: usize, const MANTISSA: usize, const PARTS: usize> PartialEq
     for Float<EXPONENT, MANTISSA, PARTS>
@@ -519,6 +524,7 @@ impl<const EXPONENT: usize, const MANTISSA: usize, const PARTS: usize>
     }
 }
 
+#[cfg(feature = "std")]
 #[test]
 fn test_comparisons() {
     use super::utils;

--- a/src/float.rs
+++ b/src/float.rs
@@ -1,6 +1,7 @@
 extern crate alloc;
 use super::bigint::BigInt;
 use super::bigint::LossFraction;
+use core::cmp::Ordering;
 
 #[cfg(feature = "std")]
 use std::println;
@@ -455,8 +456,6 @@ impl<const EXPONENT: usize, const MANTISSA: usize, const PARTS: usize>
         }
     } // round.
 }
-
-use core::cmp::Ordering;
 
 impl<const EXPONENT: usize, const MANTISSA: usize, const PARTS: usize> PartialEq
     for Float<EXPONENT, MANTISSA, PARTS>

--- a/src/functions.rs
+++ b/src/functions.rs
@@ -77,6 +77,7 @@ impl<const EXPONENT: usize, const MANTISSA: usize, const PARTS: usize>
     }
 }
 
+#[cfg(feature = "std")]
 #[test]
 fn test_sqrt() {
     use super::utils;
@@ -119,6 +120,7 @@ fn test_sqrt() {
     check(5.0120298432056786e-8, 0.0002238756316173263);
 }
 
+#[cfg(feature = "std")]
 #[test]
 fn test_min_max() {
     use super::utils;
@@ -157,6 +159,7 @@ fn test_min_max() {
     }
 }
 
+#[cfg(feature = "std")]
 #[test]
 fn test_abs() {
     use super::utils;
@@ -211,12 +214,14 @@ impl<const EXPONENT: usize, const MANTISSA: usize, const PARTS: usize>
     }
 }
 
+#[cfg(feature = "std")]
 #[test]
 fn test_pi() {
     use super::FP128;
     assert_eq!(FP128::pi().as_f64(), std::f64::consts::PI);
 }
 
+#[cfg(feature = "std")]
 #[test]
 fn test_e() {
     use super::{FP128, FP32};
@@ -247,7 +252,7 @@ impl<const EXPONENT: usize, const MANTISSA: usize, const PARTS: usize>
     /// Returns the remainder from a division of two floats. This is equivalent
     /// to rust 'rem' or c 'fmod'.
     pub fn rem(&self, rhs: Self) -> Self {
-        use std::ops::Sub;
+        use core::ops::Sub;
         // Handle NaNs.
         if self.is_nan() || rhs.is_nan() || self.is_inf() || rhs.is_zero() {
             return Self::nan(self.get_sign());
@@ -294,12 +299,13 @@ fn test_scale() {
     assert_eq!(z.as_f64(), 0.5);
 }
 
+#[cfg(feature = "std")]
 #[test]
 fn test_rem() {
     use super::utils;
     use super::utils::Lfsr;
     use super::FP64;
-    use std::ops::Rem;
+    use core::ops::Rem;
 
     fn check_two_numbers(v0: f64, v1: f64) {
         let f0 = FP64::from_f64(v0);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,6 +63,11 @@
 //!    println!("{}", b); // Prints 2648!
 //!```
 
+#![no_std]
+
+#[cfg(feature = "std")]
+extern crate std;
+
 /// Creates a new Float<> type with a specific number of bits for the exponent and mantissa.
 /// The macros selects the appropriate size for the underlying storage.
 #[macro_export]

--- a/src/string.rs
+++ b/src/string.rs
@@ -2,9 +2,10 @@ extern crate alloc;
 
 use super::bigint::BigInt;
 use super::float::Float;
-use core::fmt::Display;
 use alloc::string::{String, ToString};
-use alloc::vec::{Vec};
+use alloc::vec::Vec;
+use core::fmt::Display;
+use core::cmp::Ordering;
 
 #[cfg(test)]
 #[cfg(feature = "std")]
@@ -29,7 +30,7 @@ impl<const EXPONENT: usize, const MANTISSA: usize, const PARTS: usize>
         let mut mantissa: BigNum = self.get_mantissa().cast();
 
         match exp.cmp(&0) {
-            core::cmp::Ordering::Less => {
+            Ordering::Less => {
                 // The number is not yet an integer, we need to convert it using
                 // the method:
                 // mmmmm * 5^(e) * 10 ^(-e) == mmmmm * 10 ^ (-e);
@@ -43,7 +44,7 @@ impl<const EXPONENT: usize, const MANTISSA: usize, const PARTS: usize>
                 debug_assert!(!overflow);
                 exp = -exp;
             }
-            core::cmp::Ordering::Equal | core::cmp::Ordering::Greater => {
+            Ordering::Equal | Ordering::Greater => {
                 // The number is already an integer, just align it.
                 // In this case, E - M > 0, so we are aligning the larger
                 // integers, for example [1.mmmm * e^15], in FP16 (where M=10).

--- a/src/string.rs
+++ b/src/string.rs
@@ -1,6 +1,15 @@
+extern crate alloc;
+
 use super::bigint::BigInt;
 use super::float::Float;
-use std::fmt::Display;
+use core::fmt::Display;
+use alloc::string::{String, ToString};
+use alloc::vec::{Vec};
+
+#[cfg(test)]
+#[cfg(feature = "std")]
+use std::{println, format};
+
 
 // Use a bigint for the decimal conversions.
 type BigNum = BigInt<50>;
@@ -20,7 +29,7 @@ impl<const EXPONENT: usize, const MANTISSA: usize, const PARTS: usize>
         let mut mantissa: BigNum = self.get_mantissa().cast();
 
         match exp.cmp(&0) {
-            std::cmp::Ordering::Less => {
+            core::cmp::Ordering::Less => {
                 // The number is not yet an integer, we need to convert it using
                 // the method:
                 // mmmmm * 5^(e) * 10 ^(-e) == mmmmm * 10 ^ (-e);
@@ -34,7 +43,7 @@ impl<const EXPONENT: usize, const MANTISSA: usize, const PARTS: usize>
                 debug_assert!(!overflow);
                 exp = -exp;
             }
-            std::cmp::Ordering::Equal | std::cmp::Ordering::Greater => {
+            core::cmp::Ordering::Equal | core::cmp::Ordering::Greater => {
                 // The number is already an integer, just align it.
                 // In this case, E - M > 0, so we are aligning the larger
                 // integers, for example [1.mmmm * e^15], in FP16 (where M=10).
@@ -127,11 +136,12 @@ impl<const EXPONENT: usize, const MANTISSA: usize, const PARTS: usize>
 impl<const EXPONENT: usize, const MANTISSA: usize, const PARTS: usize> Display
     for Float<EXPONENT, MANTISSA, PARTS>
 {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(f, "{}", self.convert_to_string())
     }
 }
 
+#[cfg(feature = "std")]
 #[test]
 fn test_convert_to_string() {
     use crate::FP16;
@@ -173,6 +183,7 @@ fn test_fuzz_printing() {
     }
 }
 
+#[cfg(feature = "std")]
 #[test]
 fn test_print_sqrt() {
     type FP = crate::FP128;
@@ -190,6 +201,7 @@ fn test_print_sqrt() {
 }
 
 #[test]
+#[cfg(feature = "std")]
 fn test_readme_example() {
     use crate::new_float_type;
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -10,6 +10,7 @@ fn test_masking() {
     assert_eq!(mask(8), 255);
 }
 
+#[cfg(feature = "std")]
 #[allow(dead_code)]
 /// Returns list of interesting values that various tests use to catch edge cases.
 pub fn get_special_test_values() -> [f64; 20] {


### PR DESCRIPTION
Changes:
- [x] add default `std` environment
- [x] exchange `std` with `core` and `alloc` equivalents
- [x] conditional tests for `std` (due to need for `print`/`println` - could these be avoided?) 

Closes #3 