### PR TITLE
Implement float parsing fixes #6

### DIFF
--- a/src/bigint.rs
+++ b/src/bigint.rs
@@ -288,7 +288,7 @@ impl BigInt {
 
     /// Implements addition of the 'rhs' sequence of words to this number.
     #[allow(clippy::needless_range_loop)]
-    fn inplace_add_slice(&mut self, rhs: &[u64]) {
+    pub(crate) fn inplace_add_slice(&mut self, rhs: &[u64]) {
         self.grow(rhs.len());
         let mut carry: bool = false;
         for i in 0..rhs.len() {


### PR DESCRIPTION
Note that things like 1.2 when made to_string spit out incorrect results (like 1.199999999) but this seems to be an issue in the to_string impl as the same happens with from_f64(1.2)